### PR TITLE
Methods to render the PDF within a certain size preserving aspect ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ Add the sources files in the `UIImage+PDF` sub folder to your project. Use the f
 Then simply call one of the `UIImage` class methods as shown here:
 
 	UIImage *img = [ UIImage imageWithPDFNamed:@"YingYang.pdf" atSize:CGSizeMake( 40, 40 ) ];
+	UIImage *img = [ UIImage imageWithPDFNamed:@"YingYang.pdf" fitSize:CGSizeMake( 90, 50 ) ];
 	UIImage *img = [ UIImage imageWithPDFNamed:@"YingYang.pdf" atWidth:60 ];
 	UIImage *img = [ UIImage imageWithPDFNamed:@"YingYang.pdf" atHeight:90 ];
 	UIImage *img = [ UIImage originalSizeImageWithPDFNamed:@"YingYang.pdf" ];
 
-The `atWidth:` and `atHeight:` methods are particularly useful as they preserve the aspect ratio of the source PDF.
+The `fitSize:`, `atWidth:` and `atHeight:` methods are particularly useful as they preserve the aspect ratio of the source PDF.
 
 An example project is included in this repository. The important code is in `viewDidLoad:` in `UIImage_PDF_exampleViewController.m`.
 

--- a/UIImage+PDF/UIImage+PDF.h
+++ b/UIImage+PDF/UIImage+PDF.h
@@ -29,6 +29,9 @@
 +(UIImage *) imageWithPDFNamed:(NSString *)resourceName atHeight:(CGFloat)height atPage:(int)page;
 +(UIImage *) imageWithPDFNamed:(NSString *)resourceName atHeight:(CGFloat)height;
 
++(UIImage *) imageWithPDFNamed:(NSString *)resourceName fitSize:(CGSize)size atPage:(int)page;
++(UIImage *) imageWithPDFNamed:(NSString *)resourceName fitSize:(CGSize)size;
+
 +(UIImage *) originalSizeImageWithPDFNamed:(NSString *)resourceName atPage:(int)page;
 +(UIImage *) originalSizeImageWithPDFNamed:(NSString *)resourceName;
 
@@ -43,6 +46,9 @@
 
 +(UIImage *) imageWithPDFURL:(NSURL *)URL atHeight:(CGFloat)height atPage:(int)page;
 +(UIImage *) imageWithPDFURL:(NSURL *)URL atHeight:(CGFloat)height;
+
++(UIImage *) imageWithPDFURL:(NSURL *)URL fitSize:(CGSize)size atPage:(int)page;
++(UIImage *) imageWithPDFURL:(NSURL *)URL fitSize:(CGSize)size;
 
 +(UIImage *) originalSizeImageWithPDFURL:(NSURL *)URL atPage:(int)page;
 +(UIImage *) originalSizeImageWithPDFURL:(NSURL *)URL;

--- a/UIImage+PDF/UIImage+PDF.m
+++ b/UIImage+PDF/UIImage+PDF.m
@@ -120,6 +120,15 @@
     return [ self imageWithPDFURL:[ PDFView resourceURLForName:resourceName ] atHeight:height ];
 }
 
++(UIImage *) imageWithPDFNamed:(NSString *)resourceName fitSize:(CGSize)size atPage:(int)page
+{
+    return [ self imageWithPDFURL:[ PDFView resourceURLForName:resourceName] fitSize:size atPage:page ];
+}
+
++(UIImage *) imageWithPDFNamed:(NSString *)resourceName fitSize:(CGSize)size
+{
+    return [ self imageWithPDFURL:[ PDFView resourceURLForName:resourceName] fitSize:size ];
+}
 
 
 +(UIImage *) originalSizeImageWithPDFNamed:(NSString *)resourceName atPage:(int)page
@@ -177,6 +186,25 @@
 }
 
 
++(UIImage *) imageWithPDFURL:(NSURL *)URL fitSize:(CGSize)size atPage:(int)page
+{
+    // Get dimensions
+    CGRect mediaRect = [ PDFView mediaRectForURL:URL ];
+    
+    // Calculate scale factor
+    CGFloat scaleFactor = MAX(mediaRect.size.width / size.width, mediaRect.size.height / size.height);
+    
+    // Create new size
+    CGSize newSize = CGSizeMake( ceilf( mediaRect.size.width / scaleFactor ), ceilf( mediaRect.size.height / scaleFactor ));
+    
+    // Return image
+    return [ UIImage imageWithPDFURL:URL atSize:newSize atPage:page ];
+}
+
++(UIImage *) imageWithPDFURL:(NSURL *)URL fitSize:(CGSize)size
+{
+    return [ UIImage imageWithPDFURL:URL fitSize:size atPage:1 ];
+}
 
 
 +(UIImage *) imageWithPDFURL:(NSURL *)URL atWidth:(CGFloat)width atPage:(int)page


### PR DESCRIPTION
Created fitSize: methods that will render the PDF image fitting within the given CGSize, but always respecting the aspect ratio.

What did we do?
- Added imageWithPDFNamed:fitSize:atPage: and imageWithPDFURL:fitSize:atPage: methods (and the variations without atPage:)
- Updated Readme.md so it mentions the fitSize: method

I think these methods can be useful for a lot of people, so I'll hope you'll accept this pull request! Let me know if there is something we should update before you can accept the pull.req.!
