### PR TITLE
Prevent invalid path from crashing the entire app and get correct mediarect

### DIFF
--- a/UIImage+PDF/PDFView.m
+++ b/UIImage+PDF/PDFView.m
@@ -93,7 +93,15 @@
 
 +(NSURL *)resourceURLForName:(NSString *)resourceName
 {
-    return ( resourceName ) ? [ NSURL fileURLWithPath:[[ NSBundle mainBundle ] pathForResource:resourceName ofType:nil ]] : nil;
+    NSString *path = [[ NSBundle mainBundle ] pathForResource:resourceName ofType:nil ];
+    if( path == nil )
+    {
+        return nil;
+    }
+    else
+    {
+        return ( resourceName ) ? [ NSURL fileURLWithPath:path] : nil;
+    }
 }
 
 

--- a/UIImage+PDF/UIImage+PDF.m
+++ b/UIImage+PDF/UIImage+PDF.m
@@ -188,6 +188,11 @@
 
 +(UIImage *) imageWithPDFURL:(NSURL *)URL fitSize:(CGSize)size atPage:(int)page
 {
+    if ( URL == nil )
+    {
+        return nil;
+    }
+    
     // Get dimensions
     CGRect mediaRect = [ PDFView mediaRectForURL:URL atPage:page ];
     
@@ -209,6 +214,11 @@
 
 +(UIImage *) imageWithPDFURL:(NSURL *)URL atWidth:(CGFloat)width atPage:(int)page
 {
+    if ( URL == nil )
+    {
+        return nil;
+    }
+    
     CGRect mediaRect = [ PDFView mediaRectForURL:URL atPage:page ];
     CGFloat aspectRatio = mediaRect.size.width / mediaRect.size.height;
     
@@ -226,6 +236,11 @@
 
 +(UIImage *) imageWithPDFURL:(NSURL *)URL atHeight:(CGFloat)height atPage:(int)page
 {
+    if ( URL == nil )
+    {
+        return nil;
+    }
+    
     CGRect mediaRect = [ PDFView mediaRectForURL:URL atPage:page ];
     CGFloat aspectRatio = mediaRect.size.width / mediaRect.size.height;
     
@@ -243,6 +258,11 @@
 
 +(UIImage *) originalSizeImageWithPDFURL:(NSURL *)URL atPage:(int)page
 {
+    if ( URL == nil )
+    {
+        return nil;
+    }
+    
     CGRect mediaRect = [ PDFView mediaRectForURL:URL atPage:page ];
     
     return [ UIImage imageWithPDFURL:URL atSize:mediaRect.size atPage:page ];


### PR DESCRIPTION
Hi!

This pull req contains 2 commits. One contains a fix for invalid paths, the library will now just return nil objects instead of crashing. This is more like UIImage is behaving in general and somewhat easier to work with if you generate filenames dynamically and it's possible that the image doesn't exists.

The second makes sure the correct mediarect is returned, if you rendered a image on page 3 (or any page other then 1) the mediarect from page 1 was used. That is not necesseraly the correct rect, this commit fixes that.

Hope you will take this changes in! Let me know if we need to change or tweak anything to make it in to your repos!

Cheers,
Mathijs Kadijk
