### PR TITLE
Bugfixes to screenscale for iPhone 6 Plus (@3x) resolution & caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build/
 *.mode1v3
 xcuserdata/
 *.xcworkspace/
+
+.DS_Store

--- a/UIImage+PDF/UIImage+PDF.h
+++ b/UIImage+PDF/UIImage+PDF.h
@@ -21,7 +21,7 @@
 
 +(UIImage *) imageOrPDFNamed:(NSString *)resourceName; 
 +(UIImage *) imageOrPDFWithContentsOfFile:(NSString *)path;
-
++(NSInteger) imageOrPDFScreenScale;
 
 +(UIImage *) imageWithPDFNamed:(NSString *)resourceName atSize:(CGSize)size atPage:(NSUInteger)page;
 +(UIImage *) imageWithPDFNamed:(NSString *)resourceName atSize:(CGSize)size;

--- a/UIImage+PDF/UIImage+PDF.m
+++ b/UIImage+PDF/UIImage+PDF.m
@@ -65,6 +65,14 @@ static BOOL _shouldCache = NO;
     }
 }
 
++(NSInteger) imageOrPDFScreenScale {
+    NSInteger screenScaleFactor = 1;
+    if ( [[UIScreen mainScreen] respondsToSelector:@selector(scale)] ) {
+        CGFloat screenScale = [[[UIScreen mainScreen] valueForKey:@"scale"] floatValue];
+        screenScaleFactor = [[NSNumber numberWithFloat:screenScale] integerValue];
+    }
+    return screenScaleFactor;
+}
 
 #pragma mark - Cacheing
 
@@ -289,17 +297,17 @@ static BOOL _shouldCache = NO;
     
     NSString *cacheFilename = [ self cacheFilenameForData:data atSize:size atScaleFactor:[ UIScreen mainScreen ].scale atPage:page ];
     
-    if([[ NSFileManager defaultManager ] fileExistsAtPath:cacheFilename ])
+    if( [[ NSFileManager defaultManager ] fileExistsAtPath:cacheFilename ] && !_shouldCache )
     {
        //NSLog( @"Cache hit" );
         
-        pdfImage = [ UIImage imageWithCGImage:[[ UIImage imageWithContentsOfFile:cacheFilename ] CGImage ] scale:[ UIScreen mainScreen ].scale orientation:UIImageOrientationUp ];
+        pdfImage = [ UIImage imageWithCGImage:[[ UIImage imageWithContentsOfFile:cacheFilename ] CGImage ] scale:[UIImage imageOrPDFScreenScale] orientation:UIImageOrientationUp ];
     }
     else
     {
        //NSLog( @"Cache miss" );
         
-        UIGraphicsBeginImageContextWithOptions( size, NO, [ UIScreen mainScreen ].scale );
+        UIGraphicsBeginImageContextWithOptions( size, NO, [UIImage imageOrPDFScreenScale] );
         
         [ PDFView renderIntoContext:UIGraphicsGetCurrentContext() url:nil data:data size:size page:page ];
         pdfImage = UIGraphicsGetImageFromCurrentImageContext();
@@ -321,7 +329,7 @@ static BOOL _shouldCache = NO;
 {
     UIImage *pdfImage = nil;
     
-    NSString *cacheFilename = [ self cacheFilenameForURL:URL atSize:size atScaleFactor:[ UIScreen mainScreen ].scale atPage:page ];
+    NSString *cacheFilename = [ self cacheFilenameForURL:URL atSize:size atScaleFactor:[UIImage imageOrPDFScreenScale] atPage:page ];
     
     
     /**
@@ -334,17 +342,17 @@ static BOOL _shouldCache = NO;
     }
     
     
-    if([[ NSFileManager defaultManager ] fileExistsAtPath:cacheFilename ])
+    if( [[ NSFileManager defaultManager ] fileExistsAtPath:cacheFilename ] && !_shouldCache )
     {
         //NSLog( @"Cache hit" );
         
-        pdfImage = [ UIImage imageWithCGImage:[[ UIImage imageWithContentsOfFile:cacheFilename ] CGImage ] scale:[ UIScreen mainScreen ].scale orientation:UIImageOrientationUp ];
+        pdfImage = [ UIImage imageWithCGImage:[[ UIImage imageWithContentsOfFile:cacheFilename ] CGImage ] scale:[UIImage imageOrPDFScreenScale] orientation:UIImageOrientationUp ];
     }
     else 
     {
         //NSLog( @"Cache miss" );
     
-        UIGraphicsBeginImageContextWithOptions( size, NO, [ UIScreen mainScreen ].scale );
+        UIGraphicsBeginImageContextWithOptions( size, NO, [UIImage imageOrPDFScreenScale] );
         
         [ PDFView renderIntoContext:UIGraphicsGetCurrentContext() url:URL data:nil size:size page:page ];
         pdfImage = UIGraphicsGetImageFromCurrentImageContext();


### PR DESCRIPTION
- Fixed issue with ignoring of caching parameter (did use cached files even if you told UIImage+PDF otherwise
  )
- Fixed issue with using wrong rendering scale (was detecting @2x on an iPhone 6 Plus); added a convenience method for this now.

Signed-off-by: trailblazr
