### PR TITLE
Fix error when adding to Swift project

### DIFF
--- a/UIImage+PDF/UIView+Image.h
+++ b/UIImage+PDF/UIView+Image.h
@@ -10,7 +10,8 @@
 
 @interface UIView( Image )
 
--(UIImage *) image;
+@property (nonatomic) UIImage *image;
+
 -(void) savePNG:(NSString *)filePath;
 -(void) saveJPEG:(NSString *)filePath :(float)quality;
 

--- a/UIImage+PDF/UIView+Image.m
+++ b/UIImage+PDF/UIView+Image.m
@@ -28,7 +28,7 @@
 	return image;
 }
 
-
+- (void)setImage:(UIImage *)image {}
 
 -(void) savePNG:(NSString *)filePath
 {


### PR DESCRIPTION
The method `- (UIImage *)image` in the `UIView+Image` category causes an error in Swift projects.
The error message is:

```
getter for 'image' with Objective-C selector 'image' conflicts with method 'image()' from superclass 'UIView' with the same Objective-C selector
```

Assignments to the `image` property of `UIImageView` in Swift with `.image =` will also get `Cannot assign to property: 'self' is immutable` error.

This pull request attempts to fix those errors.
