### PR TITLE
Rename pdfview to avoid linker warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ An example project is included in this repository. The important code is in `vie
 ARC
 ---
 
-_**If your project doesn't use ARC**: you must add the `-fobjc-arc` compiler flag to `NSData+MD5.m`, `NSString+MD5.m`, `PDFView.m`, `UIImage+PDF.m` and `UIView+Image.m` in Target Settings ==> Build Phases ==> Compile Sources._
+_**If your project doesn't use ARC**: you must add the `-fobjc-arc` compiler flag to `NSData+MD5.m`, `NSString+MD5.m`, `NTBPDFView.m`, `UIImage+PDF.m` and `UIView+Image.m` in Target Settings ==> Build Phases ==> Compile Sources._
 
 
 Disk Cacheing 

--- a/UIImage+PDF example.xcodeproj/project.pbxproj
+++ b/UIImage+PDF example.xcodeproj/project.pbxproj
@@ -16,7 +16,7 @@
 		28AD733F0D9D9553002E5188 /* MainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28AD733E0D9D9553002E5188 /* MainWindow.xib */; };
 		28D7ACF80DDB3853001CB0EB /* UIImage_PDF_exampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 28D7ACF70DDB3853001CB0EB /* UIImage_PDF_exampleViewController.m */; };
 		A60041BF1779A5C500128861 /* NSData+MD5.m in Sources */ = {isa = PBXBuildFile; fileRef = A60041BE1779A5C500128861 /* NSData+MD5.m */; };
-		A6685B1D1449C642006A3A42 /* PDFView.m in Sources */ = {isa = PBXBuildFile; fileRef = A6685B181449C642006A3A42 /* PDFView.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		A6685B1D1449C642006A3A42 /* NTBPDFView.m in Sources */ = {isa = PBXBuildFile; fileRef = A6685B181449C642006A3A42 /* NTBPDFView.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		A6685B1E1449C642006A3A42 /* UIImage+PDF.m in Sources */ = {isa = PBXBuildFile; fileRef = A6685B1A1449C642006A3A42 /* UIImage+PDF.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		A6685B1F1449C642006A3A42 /* UIView+Image.m in Sources */ = {isa = PBXBuildFile; fileRef = A6685B1C1449C642006A3A42 /* UIView+Image.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		A6685B3B1449CC1C006A3A42 /* YingYang.pdf in Resources */ = {isa = PBXBuildFile; fileRef = A6685B3A1449CC1C006A3A42 /* YingYang.pdf */; };
@@ -41,8 +41,8 @@
 		8D1107310486CEB800E47090 /* UIImage_PDF_example-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "UIImage_PDF_example-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = "<group>"; };
 		A60041BD1779A5C500128861 /* NSData+MD5.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+MD5.h"; sourceTree = "<group>"; };
 		A60041BE1779A5C500128861 /* NSData+MD5.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+MD5.m"; sourceTree = "<group>"; };
-		A6685B171449C642006A3A42 /* PDFView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PDFView.h; sourceTree = "<group>"; };
-		A6685B181449C642006A3A42 /* PDFView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PDFView.m; sourceTree = "<group>"; };
+		A6685B171449C642006A3A42 /* NTBPDFView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NTBPDFView.h; sourceTree = "<group>"; };
+		A6685B181449C642006A3A42 /* NTBPDFView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NTBPDFView.m; sourceTree = "<group>"; };
 		A6685B191449C642006A3A42 /* UIImage+PDF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+PDF.h"; sourceTree = "<group>"; };
 		A6685B1A1449C642006A3A42 /* UIImage+PDF.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+PDF.m"; sourceTree = "<group>"; };
 		A6685B1B1449C642006A3A42 /* UIView+Image.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+Image.h"; sourceTree = "<group>"; };
@@ -139,8 +139,8 @@
 				A60041BE1779A5C500128861 /* NSData+MD5.m */,
 				A6CF4D5D15384D12000AA6BB /* NSString+MD5.h */,
 				A6CF4D5E15384D12000AA6BB /* NSString+MD5.m */,
-				A6685B171449C642006A3A42 /* PDFView.h */,
-				A6685B181449C642006A3A42 /* PDFView.m */,
+				A6685B171449C642006A3A42 /* NTBPDFView.h */,
+				A6685B181449C642006A3A42 /* NTBPDFView.m */,
 				A6685B191449C642006A3A42 /* UIImage+PDF.h */,
 				A6685B1A1449C642006A3A42 /* UIImage+PDF.m */,
 				A6685B1B1449C642006A3A42 /* UIView+Image.h */,
@@ -226,7 +226,7 @@
 				1D60589B0D05DD56006BFB54 /* main.m in Sources */,
 				1D3623260D0F684500981E51 /* UIImage_PDF_exampleAppDelegate.m in Sources */,
 				28D7ACF80DDB3853001CB0EB /* UIImage_PDF_exampleViewController.m in Sources */,
-				A6685B1D1449C642006A3A42 /* PDFView.m in Sources */,
+				A6685B1D1449C642006A3A42 /* NTBPDFView.m in Sources */,
 				A6685B1E1449C642006A3A42 /* UIImage+PDF.m in Sources */,
 				A6685B1F1449C642006A3A42 /* UIView+Image.m in Sources */,
 				A6CF4D5F15384D12000AA6BB /* NSString+MD5.m in Sources */,

--- a/UIImage+PDF/NTBPDFView.h
+++ b/UIImage+PDF/NTBPDFView.h
@@ -1,5 +1,5 @@
 //
-//  PDFView.h
+//  NTBPDFView.h
 //
 //  Created by Nigel Barber on 15/10/2011.
 //  Copyright 2011 Mindbrix Limited. All rights reserved.
@@ -8,7 +8,7 @@
 #import <UIKit/UIKit.h>
 
 
-@interface PDFView : UIView 
+@interface NTBPDFView : UIView
 {
 
 }

--- a/UIImage+PDF/NTBPDFView.m
+++ b/UIImage+PDF/NTBPDFView.m
@@ -1,14 +1,14 @@
 //
-//  PDFView.m
+//  NTBPDFView.m
 //
 //  Created by Nigel Barber on 15/10/2011.
 //  Copyright 2011 Mindbrix Limited. All rights reserved.
 //
 
-#import "PDFView.h"
+#import "NTBPDFView.h"
 
 
-@implementation PDFView
+@implementation NTBPDFView
 
 @synthesize page = m_page;
 @synthesize resourceName = m_resourceName;
@@ -33,7 +33,7 @@
 {
 	m_resourceName = resourceName;
 	
-    self.resourceURL = [ PDFView resourceURLForName: self.resourceName ];
+    self.resourceURL = [ NTBPDFView resourceURLForName: self.resourceName ];
 }
 
 
@@ -54,7 +54,7 @@
 
 +(CGRect) mediaRect:(NSString *)resourceName
 {
-    return [ PDFView mediaRectForURL:[ PDFView resourceURLForName: resourceName ]];
+    return [ NTBPDFView mediaRectForURL:[ NTBPDFView resourceURLForName: resourceName ]];
 }
 
 

--- a/UIImage+PDF/UIImage+PDF.h
+++ b/UIImage+PDF/UIImage+PDF.h
@@ -7,7 +7,7 @@
 
 #import <UIKit/UIKit.h>
 #import "UIView+Image.h"
-#import "PDFView.h"
+#import "NTBPDFView.h"
 #import "NSData+MD5.h"
 #import "NSString+MD5.h"
 

--- a/UIImage+PDF/UIImage+PDF.m
+++ b/UIImage+PDF/UIImage+PDF.m
@@ -123,52 +123,52 @@ static BOOL _shouldCacheOnDisk = YES;
 
 +(UIImage *) imageWithPDFNamed:(NSString *)resourceName atSize:(CGSize)size atPage:(NSUInteger)page
 {
-    return [ self imageWithPDFURL:[ PDFView resourceURLForName:resourceName ] atSize:size atPage:page ];
+    return [ self imageWithPDFURL:[ NTBPDFView resourceURLForName:resourceName ] atSize:size atPage:page ];
 }
 
 +(UIImage *) imageWithPDFNamed:(NSString *)resourceName atSize:(CGSize)size
 {
-    return [ self imageWithPDFURL:[ PDFView resourceURLForName:resourceName ] atSize:size ];
+    return [ self imageWithPDFURL:[ NTBPDFView resourceURLForName:resourceName ] atSize:size ];
 }
 
 +(UIImage *) imageWithPDFNamed:(NSString *)resourceName atWidth:(CGFloat)width atPage:(NSUInteger)page
 {
-    return [ self imageWithPDFURL:[ PDFView resourceURLForName:resourceName ] atWidth:width atPage:page ];
+    return [ self imageWithPDFURL:[ NTBPDFView resourceURLForName:resourceName ] atWidth:width atPage:page ];
 }
 
 +(UIImage *) imageWithPDFNamed:(NSString *)resourceName atWidth:(CGFloat)width
 {
-    return [ self imageWithPDFURL:[ PDFView resourceURLForName:resourceName ] atWidth:width ];
+    return [ self imageWithPDFURL:[ NTBPDFView resourceURLForName:resourceName ] atWidth:width ];
 }
 
 +(UIImage *) imageWithPDFNamed:(NSString *)resourceName atHeight:(CGFloat)height atPage:(NSUInteger)page
 {
-    return [ self imageWithPDFURL:[ PDFView resourceURLForName:resourceName ] atHeight:height atPage:page ];
+    return [ self imageWithPDFURL:[ NTBPDFView resourceURLForName:resourceName ] atHeight:height atPage:page ];
 }
 
 +(UIImage *) imageWithPDFNamed:(NSString *)resourceName atHeight:(CGFloat)height
 {
-    return [ self imageWithPDFURL:[ PDFView resourceURLForName:resourceName ] atHeight:height ];
+    return [ self imageWithPDFURL:[ NTBPDFView resourceURLForName:resourceName ] atHeight:height ];
 }
 
 +(UIImage *) imageWithPDFNamed:(NSString *)resourceName fitSize:(CGSize)size atPage:(NSUInteger)page
 {
-    return [ self imageWithPDFURL:[ PDFView resourceURLForName:resourceName] fitSize:size atPage:page ];
+    return [ self imageWithPDFURL:[ NTBPDFView resourceURLForName:resourceName] fitSize:size atPage:page ];
 }
 
 +(UIImage *) imageWithPDFNamed:(NSString *)resourceName fitSize:(CGSize)size
 {
-    return [ self imageWithPDFURL:[ PDFView resourceURLForName:resourceName] fitSize:size ];
+    return [ self imageWithPDFURL:[ NTBPDFView resourceURLForName:resourceName] fitSize:size ];
 }
 
 +(UIImage *) originalSizeImageWithPDFNamed:(NSString *)resourceName atPage:(NSUInteger)page
 {
-    return [ self originalSizeImageWithPDFURL:[ PDFView resourceURLForName:resourceName ] atPage:page ];
+    return [ self originalSizeImageWithPDFURL:[ NTBPDFView resourceURLForName:resourceName ] atPage:page ];
 }
 
 +(UIImage *) originalSizeImageWithPDFNamed:(NSString *)resourceName
 {
-    return [ self originalSizeImageWithPDFURL:[ PDFView resourceURLForName:resourceName ]];
+    return [ self originalSizeImageWithPDFURL:[ NTBPDFView resourceURLForName:resourceName ]];
 }
 
 
@@ -176,7 +176,7 @@ static BOOL _shouldCacheOnDisk = YES;
 
 +(UIImage *) originalSizeImageWithPDFData:(NSData *)data
 {
-    CGRect mediaRect = [ PDFView mediaRectForData:data atPage:1 ];
+    CGRect mediaRect = [ NTBPDFView mediaRectForData:data atPage:1 ];
 
     return [ UIImage imageWithPDFData:data atSize:mediaRect.size atPage:1 ];
 }
@@ -191,7 +191,7 @@ static BOOL _shouldCacheOnDisk = YES;
     if ( data == nil )
         return nil;
     
-    CGRect mediaRect = [ PDFView mediaRectForData:data atPage:page ];
+    CGRect mediaRect = [ NTBPDFView mediaRectForData:data atPage:page ];
     CGFloat aspectRatio = mediaRect.size.width / mediaRect.size.height;
     CGSize size = CGSizeMake( width, ceil( width / aspectRatio ));
     
@@ -208,7 +208,7 @@ static BOOL _shouldCacheOnDisk = YES;
     if ( data == nil )
         return nil;
     
-    CGRect mediaRect = [ PDFView mediaRectForData:data atPage:page ];
+    CGRect mediaRect = [ NTBPDFView mediaRectForData:data atPage:page ];
     CGFloat aspectRatio = mediaRect.size.width / mediaRect.size.height;
     CGSize size = CGSizeMake( ceil( height * aspectRatio ), height );
     
@@ -225,7 +225,7 @@ static BOOL _shouldCacheOnDisk = YES;
     if ( data == nil )
         return nil;
     
-    CGRect mediaRect = [ PDFView mediaRectForData:data atPage:page ];
+    CGRect mediaRect = [ NTBPDFView mediaRectForData:data atPage:page ];
     CGFloat scaleFactor = MAX( mediaRect.size.width / size.width, mediaRect.size.height / size.height );
     CGSize newSize = CGSizeMake( ceil( mediaRect.size.width / scaleFactor ), ceil( mediaRect.size.height / scaleFactor ));
     
@@ -258,7 +258,7 @@ static BOOL _shouldCacheOnDisk = YES;
         CGContextRef ctx = CGBitmapContextCreate(NULL, size.width * screenScale, size.height * screenScale, 8, 0, colorSpace, kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedFirst);
         CGContextScaleCTM(ctx, screenScale, screenScale);
         
-        [PDFView renderIntoContext:ctx url:nil data:data size:size page:page];
+        [NTBPDFView renderIntoContext:ctx url:nil data:data size:size page:page];
         CGImageRef image = CGBitmapContextCreateImage(ctx);
         pdfImage = [[UIImage alloc] initWithCGImage:image scale:screenScale orientation:UIImageOrientationUp];
         
@@ -308,7 +308,7 @@ static BOOL _shouldCacheOnDisk = YES;
         CGContextRef ctx = CGBitmapContextCreate(NULL, size.width * screenScale, size.height * screenScale, 8, 0, colorSpace, kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedFirst);
         CGContextScaleCTM(ctx, screenScale, screenScale);
         
-        [PDFView renderIntoContext:ctx url:URL data:nil size:size page:page];
+        [NTBPDFView renderIntoContext:ctx url:URL data:nil size:size page:page];
         CGImageRef image = CGBitmapContextCreateImage(ctx);
         pdfImage = [[UIImage alloc] initWithCGImage:image scale:screenScale orientation:UIImageOrientationUp];
         
@@ -344,7 +344,7 @@ static BOOL _shouldCacheOnDisk = YES;
         return nil;
     
     // Get dimensions
-    CGRect mediaRect = [ PDFView mediaRectForURL:URL atPage:page ];
+    CGRect mediaRect = [ NTBPDFView mediaRectForURL:URL atPage:page ];
     
     // Calculate scale factor
     CGFloat scaleFactor = MAX(mediaRect.size.width / size.width, mediaRect.size.height / size.height);
@@ -366,7 +366,7 @@ static BOOL _shouldCacheOnDisk = YES;
     if ( URL == nil )
         return nil;
     
-    CGRect mediaRect = [ PDFView mediaRectForURL:URL atPage:page ];
+    CGRect mediaRect = [ NTBPDFView mediaRectForURL:URL atPage:page ];
     CGFloat aspectRatio = mediaRect.size.width / mediaRect.size.height;
     
     CGSize size = CGSizeMake( width, ceil( width / aspectRatio ));
@@ -385,7 +385,7 @@ static BOOL _shouldCacheOnDisk = YES;
     if ( URL == nil )
         return nil;
     
-    CGRect mediaRect = [ PDFView mediaRectForURL:URL atPage:page ];
+    CGRect mediaRect = [ NTBPDFView mediaRectForURL:URL atPage:page ];
     CGFloat aspectRatio = mediaRect.size.width / mediaRect.size.height;
     
     CGSize size = CGSizeMake( ceil( height * aspectRatio ), height );
@@ -403,7 +403,7 @@ static BOOL _shouldCacheOnDisk = YES;
     if ( URL == nil )
         return nil;
     
-    CGRect mediaRect = [ PDFView mediaRectForURL:URL atPage:page ];
+    CGRect mediaRect = [ NTBPDFView mediaRectForURL:URL atPage:page ];
     
     return [ UIImage imageWithPDFURL:URL atSize:mediaRect.size atPage:page ];
 }


### PR DESCRIPTION
Apple has an internal class also called PDFView. As it's not defined which class should be used, the linker gives a warning about that. To avoid that, PDFView has been renamed to NTBPDFView.